### PR TITLE
[MIG][18.0]mail_parser: Migration module

### DIFF
--- a/mail_parser/__manifest__.py
+++ b/mail_parser/__manifest__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-
 {
     "name": "Mail Parser",
-    "version": "16.0.1.0.6",
+    "version": "18.0.1.0.0",
     "summary": """
         Automatically read/parse emails from aliases and convert data
         """,
@@ -15,7 +14,7 @@
     "depends": [
         "base",
         "mail"
-        ],
+    ],
     "data": [
         "security/ir.model.access.csv",
         "views/mail_alias_views.xml",

--- a/mail_parser/models/mail_alias.py
+++ b/mail_parser/models/mail_alias.py
@@ -1,45 +1,46 @@
+# -*- coding: utf-8 -*-
 import re
-
-from odoo import models, fields, api, _
+from odoo import models, fields
 from odoo.tools import html2plaintext
 
 
 class MailAlias(models.Model):
-    _inherit="mail.alias"
+    _inherit = "mail.alias"
 
     mail_parser_ids = fields.One2many(
         "mail.parser",
         "mail_alias_id",
-        string="Mail Parser rules"
+        string="Mail Parser rules",
     )
-
     mail_parser_server_action_id = fields.Many2one(
         "ir.actions.server",
-        "Mail parser server action",
+        string="Mail parser server action",
         help="The server action that should be executed automatically the moment an email is created from an alias.",
-        domain="[('model_id','=', alias_model_id)]"
+        domain="[('model_id','=', alias_model_id)]",
     )
-
     test_mail_body = fields.Html(
-        string="Mail Body"
+        string="Mail Body",
     )
 
     def _get_value_from_regex_condition(self, regex_condition, email_body):
         """
-        Extracts the value from an email body that matches the given regular expression condition.
+        Extracts the value from an email body that matches the given
+        regular expression condition.
         """
         if regex_condition and email_body:
             search_pattern = fr"{regex_condition}"
             match = re.search(search_pattern, email_body)
             if match:
                 return match.group(1)
-            return None
+        return None
 
     def test_mail_parser_rule(self):
         table_tag_open = "<table class='table'><tbody>"
         table_data_string = ''
         table_tag_close = "</tbody></table>"
-        action = self.env['ir.actions.act_window']._for_xml_id("mail_parser.parser_message_wizard_action")
+        action = self.env['ir.actions.act_window']._for_xml_id(
+            "mail_parser.parser_message_wizard_action"
+        )
         for alias in self:
             model_vals = self._prepare_mail_parser_data(alias_id=alias)
             for key, value in model_vals.items():
@@ -47,7 +48,7 @@ class MailAlias(models.Model):
         final_data_string = f"{table_tag_open}{table_data_string}{table_tag_close}"
         action['context'] = {
             'default_parser_message': final_data_string
-         }
+        }
         return action
 
     def _prepare_mail_parser_data(self, alias_id):
@@ -57,14 +58,16 @@ class MailAlias(models.Model):
             tags_to_replace = ["<b>", "</b>"]
             for tag in tags_to_replace:
                 email_body = email_body.replace(tag, "")
-            email_body=html2plaintext(email_body)
+            email_body = html2plaintext(email_body)
             for parser_id in alias_id.mail_parser_ids:
-                regex_match_value =  self._get_value_from_regex_condition(parser_id.regex_condition, email_body)
+                regex_match_value = self._get_value_from_regex_condition(
+                    parser_id.regex_condition, email_body
+                )
                 if regex_match_value:
                     model_vals[parser_id.name] = regex_match_value
                 else:
                     if parser_id.default_value:
                         model_vals[parser_id.name] = parser_id.default_value
                     else:
-                         model_vals[parser_id.name] = ''
+                        model_vals[parser_id.name] = ''
         return model_vals

--- a/mail_parser/models/mail_parser.py
+++ b/mail_parser/models/mail_parser.py
@@ -1,37 +1,32 @@
-from odoo import models, fields, api, _
+# -*- coding: utf-8 -*-
+from odoo import models, fields
 
 
 class MailParser(models.Model):
-    _name="mail.parser"
-    _description ="Mail Parser"
+    _name = "mail.parser"
+    _description = "Mail Parser"
 
     name = fields.Char(
-        string="Name"
+        string="Name",
     )
-
     regex_condition = fields.Char(
-        string="Regex condition"
+        string="Regex condition",
     )
-
     field_id = fields.Many2one(
         "ir.model.fields",
-        string="Fields"
+        string="Fields",
     )
-
     models_id = fields.Many2one(
-        "ir.model",  # model to which this rule is linked
-        string="Model"
+        "ir.model",
+        string="Model",
     )
-
     default_value = fields.Char(
-        string="Default Value"
+        string="Default Value",
     )
-
     mail_alias_id = fields.Many2one(
         "mail.alias",
-        string="Alias"
+        string="Alias",
     )
-
     should_be_unique = fields.Boolean(
         string="Should be Unique",
     )

--- a/mail_parser/models/mail_thread.py
+++ b/mail_parser/models/mail_thread.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
 import re
 from itertools import groupby
-from odoo import _, api, models
+from odoo import api, models
 from odoo.tools import html2plaintext
 
 
@@ -11,43 +12,49 @@ class MailThread(models.AbstractModel):
         """
         Prepare custom value from email
         """
-        original_custom_values = custom_values.copy()
         message = message_dict.get('body')
-        if alias_id and alias_id.mail_parser_ids:
-            mail_parser_by_model = {}
-            for models_id, grouped_lines in groupby(alias_id.mail_parser_ids, key=lambda l: l.models_id.id):
-                mail_parser_by_model[models_id] = self.env['mail.parser'].concat(*grouped_lines)
-            if mail_parser_by_model:
-                model_vals = {}
-                domain_vals = {}
-                
-                for model_id, parser_id in mail_parser_by_model.items():    
-                    for parser in parser_id:
-                        email_body = str(message)
-                        tags_to_replace = ["<b>", "</b>"]
-                        for tag in tags_to_replace:
-                            email_body = email_body.replace(tag, "")
-                        email_body = html2plaintext(email_body)
-                        regex_match_value = self._get_value_from_regex_condition(parser.regex_condition, email_body)
-                        if regex_match_value and parser.field_id.name:
-                            model_vals[parser.field_id.name] = regex_match_value
-                            if parser.should_be_unique:
-                                domain_vals[parser.field_id.name] = regex_match_value or ''
-                        else:
-                            if parser.default_value and parser.field_id.name:
-                                model_vals[parser.field_id.name] = parser.default_value
-                                if parser.should_be_unique:
-                                    domain_vals[parser.field_id.name] = parser.default_value or ''
-                            else:
-                                continue  # no default value set on this field
+        if not (alias_id and alias_id.mail_parser_ids):
+            return custom_values, message_dict, {}
 
-                if model_vals.get('email', False) and message_dict.get('email_from', False):
-                    message_dict.update({
-                        'email_from': model_vals.get('email', False)
-                    })
-                custom_values.update(model_vals)
-                return custom_values, message_dict, domain_vals
+        mail_parser_by_model = {}
+        for models_id, grouped_lines in groupby(
+            alias_id.mail_parser_ids, key=lambda l: l.models_id.id
+        ):
+            mail_parser_by_model[models_id] = self.env['mail.parser'].concat(*grouped_lines)
 
+        if not mail_parser_by_model:
+            return custom_values, message_dict, {}
+
+        model_vals = {}
+        domain_vals = {}
+
+        for model_id, parser_id in mail_parser_by_model.items():
+            for parser in parser_id:
+                email_body = str(message)
+                tags_to_replace = ["<b>", "</b>"]
+                for tag in tags_to_replace:
+                    email_body = email_body.replace(tag, "")
+                email_body = html2plaintext(email_body)
+                regex_match_value = self._get_value_from_regex_condition(
+                    parser.regex_condition, email_body
+                )
+                if regex_match_value and parser.field_id.name:
+                    model_vals[parser.field_id.name] = regex_match_value
+                    if parser.should_be_unique:
+                        domain_vals[parser.field_id.name] = regex_match_value or ''
+                else:
+                    if parser.default_value and parser.field_id.name:
+                        model_vals[parser.field_id.name] = parser.default_value
+                        if parser.should_be_unique:
+                            domain_vals[parser.field_id.name] = parser.default_value or ''
+                    else:
+                        continue
+
+        if model_vals.get('email', False) and message_dict.get('email_from', False):
+            message_dict.update({'email_from': model_vals.get('email', False)})
+
+        custom_values.update(model_vals)
+        return custom_values, message_dict, domain_vals
 
     def _prepared_domain_from_dict(self, domain_vals):
         """
@@ -55,71 +62,76 @@ class MailThread(models.AbstractModel):
         """
         domain = []
         for key, value in domain_vals.items():
-            domain.append((key,'=', value))
+            domain.append((key, '=', value))
         return domain
-
 
     @api.model
     def _message_route_process(self, message, message_dict, routes):
-        """
-        Method overwrite from
-        URL: https://github.com/odoo/odoo/blob/69b1993fb45b76110c24f5189a0ecfe9eb59a2aa/addons/mail/models/mail_thread.py#L1130
-        """
-        if not message_dict['message_type'] == 'email':
-            return super()._message_route_process(message, message_dict, routes)
-        
-        self = self.with_context(attachments_mime_plainxml=True)  # import XML attachments as text
-        # postpone setting message_dict.partner_ids after message_post, to avoid double notifications
+        self = self.with_context(attachments_mime_plainxml=True)
         original_partner_ids = message_dict.pop('partner_ids', [])
         thread_id = False
-        custom_parser_value = {}
-        # raise UserError(message)
+
         for model, thread_id, custom_values, user_id, alias in routes or ():
             subtype_id = False
             related_user = self.env['res.users'].browse(user_id)
-            Model = self.env[model].with_context(mail_create_nosubscribe=True, mail_create_nolog=True)
+            Model = self.env[model].with_context(
+                mail_create_nosubscribe=True, mail_create_nolog=True
+            )
             if not (thread_id and hasattr(Model, 'message_update') or hasattr(Model, 'message_new')):
                 raise ValueError(
                     "Undeliverable mail with Message-Id %s, model %s does not accept incoming emails" %
                     (message_dict['message_id'], model)
                 )
-                
-            if alias.mail_parser_ids:
-                custom_parser_value, custom_message_dict, domain_vals = self._mail_parser_custom(
-                                        model, 
-                                        thread_id, 
-                                        custom_values, 
-                                        user_id, alias,
-                                        message_dict)
-                custom_values = custom_parser_value
-                message_dict = custom_message_dict
+
+            if alias and alias.mail_parser_ids:
+                custom_values, message_dict, domain_vals = self._mail_parser_custom(
+                    model,
+                    thread_id,
+                    custom_values,
+                    user_id,
+                    alias,
+                    message_dict,
+                )
                 domain = self._prepared_domain_from_dict(domain_vals)
                 existing_record_id = Model.search(domain, limit=1)
                 Model = Model.with_context(
-                            custom_parser_value=custom_parser_value,
-                            alias_id=alias,
-                            existing_record_id=existing_record_id)
+                    custom_parser_value=custom_values,
+                    alias_id=alias,
+                    existing_record_id=existing_record_id,
+                )
                 if existing_record_id:
                     thread_id = existing_record_id.id
 
-            # disabled subscriptions during message_new/update to avoid having the system user running the
-            # email gateway become a follower of all inbound messages
             ModelCtx = Model.with_user(related_user).sudo()
             if thread_id and hasattr(ModelCtx, 'message_update'):
                 thread = ModelCtx.browse(thread_id)
                 thread.message_update(message_dict)
             else:
-                # if a new thread is created, parent is irrelevant
                 message_dict.pop('parent_id', None)
-                thread = ModelCtx.message_new(message_dict, custom_values)
+                try:
+                    thread = ModelCtx.message_new(message_dict, custom_values)
+                except Exception:
+                    if alias:
+                        with self.pool.cursor() as new_cr:
+                            self.with_env(self.env(cr=new_cr)).env['mail.alias'].browse(
+                                alias.id
+                            )._alias_bounce_incoming_email(
+                                message, message_dict, set_invalid=True
+                            )
+                    raise
+                else:
+                    if alias and alias.alias_status != 'valid':
+                        alias.alias_status = 'valid'
                 thread_id = thread.id
                 subtype_id = thread._creation_subtype().id
 
-            # replies to internal message are considered as notes, but parent message
-            # author is added in recipients to ensure they are notified of a private answer
+            thread_root = thread.with_user(self.env.ref('base.user_root'))
+
             parent_message = False
             if message_dict.get('parent_id'):
-                parent_message = self.env['mail.message'].sudo().browse(message_dict['parent_id'])
+                parent_message = self.env['mail.message'].sudo().browse(
+                    message_dict['parent_id']
+                )
             partner_ids = []
             if not subtype_id:
                 if message_dict.get('is_internal'):
@@ -130,53 +142,64 @@ class MailThread(models.AbstractModel):
                     subtype_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
 
             post_params = dict(subtype_id=subtype_id, partner_ids=partner_ids, **message_dict)
-            # remove computational values not stored on mail.message and avoid warnings when creating it
-            for x in ('from', 'to', 'cc', 'recipients', 'references', 'in_reply_to', 'bounced_email', 'bounced_message', 'bounced_msg_id', 'bounced_partner'):
+            for x in ('from', 'to', 'cc', 'recipients', 'references', 'in_reply_to',
+                      'x_odoo_message_id', 'is_bounce', 'bounced_email', 'bounced_message',
+                      'bounced_msg_ids', 'bounced_partner'):
                 post_params.pop(x, None)
+
             new_msg = False
-            if thread._name == 'mail.thread':  # message with parent_id not linked to record
-                new_msg = thread.message_notify(**post_params)
+            if thread_root._name == 'mail.thread':
+                new_msg = thread_root.message_notify(**post_params)
             else:
-                # parsing should find an author independently of user running mail gateway, and ensure it is not odoobot
-                partner_from_found = message_dict.get('author_id') and message_dict['author_id'] != self.env[
-                    'ir.model.data']._xmlid_to_res_id('base.partner_root')
-                thread = thread.with_context(mail_create_nosubscribe=not partner_from_found)
-                new_msg = thread.message_post(**post_params)
+                partner_from_found = (
+                    message_dict.get('author_id') and
+                    message_dict['author_id'] != self.env['ir.model.data']._xmlid_to_res_id(
+                        'base.partner_root'
+                    )
+                )
+                thread_root = thread_root.with_context(
+                    from_alias=True,
+                    mail_create_nosubscribe=not partner_from_found,
+                )
+                new_msg = thread_root.message_post(**post_params)
 
             if new_msg and original_partner_ids:
-                # postponed after message_post, because this is an external message and we don't want to create
-                # duplicate emails due to notifications
                 new_msg.write({'partner_ids': original_partner_ids})
+
         return thread_id
 
     def _get_value_from_regex_condition(self, regex_condition, email_body):
         """
-        Extracts the value from an email body that matches the given regular expression condition.
+        Extracts the value from an email body that matches the given
+        regular expression condition.
         """
         if regex_condition and email_body:
             search_pattern = fr"{regex_condition}"
             match = re.search(search_pattern, email_body)
             if match:
                 return match.group(1)
-            return None
+        return None
 
     @api.model
     def message_new(self, msg_dict, custom_values=None):
         """
-        This method extends the functionality by allowing a custom parser value in the context.
-        If 'custom_parser_value' is present and not empty, it is used to extract data.
-        The extracted data is then used to execute a server action associated with the alias_id.
+        Extends message_new to execute the server action configured on the alias
+        after a new record is created from an incoming email.
 
-        In the server action, retrieve values from the context with the key 'model_name', which
-        represents the model name and the corresponding ID of the created record.
-        Example Usage:{'res_partner': 56}
+        In the server action, retrieve values from the context with the key
+        'model_name' (model name) and 'active_id' (ID of the created record).
+        Example: {'res_partner': 56}
         """
         message_new = super().message_new(msg_dict, custom_values)
         context = dict(self._context) or {}
-        
-        if 'custom_parser_value' in context and context.get('custom_parser_value'):
+
+        if context.get('custom_parser_value'):
             alias_id = context.get('alias_id')
-            action_server = alias_id.mail_parser_server_action_id
-            if action_server:
-                action_server.sudo().with_context(data).run()
+            if alias_id:
+                action_server = alias_id.mail_parser_server_action_id
+                if action_server:
+                    action_server.sudo().with_context(
+                        model_name=self._name,
+                        active_id=message_new.id,
+                    ).run()
         return message_new

--- a/mail_parser/views/mail_alias_views.xml
+++ b/mail_parser/views/mail_alias_views.xml
@@ -1,9 +1,8 @@
 <odoo>
-    <!--  FSM task inherit form view -->
     <record id="elexo_mail_alias_form" model="ir.ui.view">
         <field name="name">mail.alias.inherit.view.tree</field>
         <field name="model">mail.alias</field>
-        <field name="inherit_id" ref="mail.view_mail_alias_form"/>
+        <field name="inherit_id" ref="mail.mail_alias_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='alias_defaults']" position="after">
                 <field name="mail_parser_server_action_id"/>
@@ -16,14 +15,14 @@
                     <page string="Mail Parser Rules" name="mail_parser_rules">
                         <separator string="Mail parser rules"/>
                         <field name="mail_parser_ids">
-                            <tree>
+                            <list>
                                 <field name="name"/>
                                 <field name="regex_condition"/>
                                 <field name="models_id" required="1"/>
                                 <field name="field_id" required="1"/>
                                 <field name="default_value"/>
                                 <field name="should_be_unique" widget="boolean_toggle"/>
-                            </tree>
+                            </list>
                             <form name="mail_parse_rules" string="Mail parser rules">
                                 <div class="oe_title">
                                     <h1>
@@ -34,7 +33,7 @@
                                     <field name="regex_condition"/>
                                     <field name="models_id" required="1"/>
                                     <field name="field_id" required="1" domain="[('model_id','=', models_id)]"/>
-                                    <field name="default_value" />
+                                    <field name="default_value"/>
                                     <field name="should_be_unique" widget="boolean_toggle"/>
                                     <field name="mail_alias_id" invisible="1"/>
                                 </group>
@@ -49,5 +48,4 @@
             </xpath>
         </field>
     </record>
-
 </odoo>

--- a/mail_parser/views/mail_parser_views.xml
+++ b/mail_parser/views/mail_parser_views.xml
@@ -14,7 +14,7 @@
                         <field name="regex_condition"/>
                         <field name="models_id" required="1"/>
                         <field name="field_id" required="1" domain="[('model_id','=', models_id)]"/>
-                        <field name="default_value" />
+                        <field name="default_value"/>
                         <field name="mail_alias_id"/>
                         <field name="should_be_unique" widget="boolean_toggle"/>
                     </group>
@@ -22,28 +22,30 @@
             </form>
         </field>
     </record>
+
     <record id="mail_parser_tree" model="ir.ui.view">
         <field name="name">mail.parser.tree</field>
         <field name="model">mail.parser</field>
         <field name="arch" type="xml">
-            <tree string="Mail Parser">
+            <list string="Mail Parser">
                 <field name="name" required="1" placeholder="Name..."/>
                 <field name="regex_condition" placeholder="First name : (\w+)"/>
-                <field name="models_id" />
+                <field name="models_id"/>
                 <field name="field_id" domain="[('model_id','=', models_id)]"/>
-                <field name="default_value" />
+                <field name="default_value"/>
                 <field name="mail_alias_id"/>
                 <field name="should_be_unique" widget="boolean_toggle"/>
-            </tree>
+            </list>
         </field>
     </record>
+
     <record id="mail_parser_action" model="ir.actions.act_window">
         <field name="name">Mail Parser</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">mail.parser</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
     </record>
-    <!-- This Menu Item must have a parent and an action -->
+
     <menuitem
         id="mail_parser_menu_act"
         name="Mail Parser"
@@ -52,5 +54,4 @@
         sequence="99"
         groups="base.group_no_one"
     />
-
 </odoo>

--- a/mail_parser/wizard/warning_message.py
+++ b/mail_parser/wizard/warning_message.py
@@ -1,4 +1,5 @@
-from odoo import models, fields, api, _
+# -*- coding: utf-8 -*-
+from odoo import models, fields
 
 
 class ParserMessage(models.TransientModel):
@@ -7,5 +8,5 @@ class ParserMessage(models.TransientModel):
 
     parser_message = fields.Html(
         string='Message',
-        required=True
+        required=True,
     )

--- a/mail_parser/wizard/warning_message_views.xml
+++ b/mail_parser/wizard/warning_message_views.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <form>
                 <div>
-                <h3>Extracted data from sample mail</h3>
+                    <h3>Extracted data from sample mail</h3>
                 </div>
                 <field name="parser_message" readonly="1" force_save="1"/>
                 <footer>
@@ -23,5 +23,4 @@
         <field name="target">new</field>
         <field name="context">{}</field>
     </record>
-
 </odoo>


### PR DESCRIPTION
Migration of mail_parser module from 16.0 to 18.0.

Changes:
- Update manifest version to 18.0.1.0.0
- Align _message_route_process with Odoo 18 (thread_root, try/except, alias_status, from_alias=True)
- Fix bug in message_new: undefined 'data' variable replaced by model_name/active_id context
- Replace tree by list in all views
- Fix inherit_id ref: mail.view_mail_alias_form -> mail.mail_alias_view_form
- Clean unused imports